### PR TITLE
Ensure destination exists or is created successfully

### DIFF
--- a/src/Filesystem/Zip.php
+++ b/src/Filesystem/Zip.php
@@ -69,14 +69,13 @@ class Zip extends ZipArchive
             'mask' => 0777
         ], $options));
 
-        if (!file_exists($destination))
-            mkdir($destination, $mask, true);
-
-        $zip = new ZipArchive;
-        if ($zip->open($source) === true) {
-            $zip->extractTo($destination);
-            $zip->close();
-            return true;
+        if (file_exists($destination) || mkdir($destination, $mask, true)) {
+            $zip = new ZipArchive;
+            if ($zip->open($source) === true) {
+                $zip->extractTo($destination);
+                $zip->close();
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
The previous code only assumed that mkdir() was successful, and if not then the ZipArchive::extractTo() would fail.
